### PR TITLE
Add Optional type annotations for README sections

### DIFF
--- a/generate_readmes.py
+++ b/generate_readmes.py
@@ -8,7 +8,7 @@ import argparse
 import os
 import sys
 from pathlib import Path
-from typing import List, Dict, Set
+from typing import List, Dict, Set, Optional
 import dspy
 
 
@@ -21,15 +21,15 @@ class READMEGenerator(dspy.Signature):
     
     title: str = dspy.OutputField(desc="Project title and one-sentence tagline")
     overview: str = dspy.OutputField(desc="1-2 paragraph overview explaining what the project is and why it exists")
-    badges: str = dspy.OutputField(desc="Relevant badges for the project (can be empty if none needed)")
-    features: str = dspy.OutputField(desc="3-7 bullet points of key features or components")
+    badges: Optional[str] = dspy.OutputField(desc="Relevant badges for the project (can be empty if none needed)")
+    features: Optional[str] = dspy.OutputField(desc="3-7 bullet points of key features or components")
     prerequisites: str = dspy.OutputField(desc="Required languages, runtimes, and package managers")
     installation: str = dspy.OutputField(desc="Step-by-step installation instructions")
     usage: str = dspy.OutputField(desc="Usage examples with code snippets")
     file_structure: str = dspy.OutputField(desc="Overview of important files and folders")
-    contributing: str = dspy.OutputField(desc="Contributing guidelines and process")
-    license_info: str = dspy.OutputField(desc="License information")
-    acknowledgments: str = dspy.OutputField(desc="Acknowledgments and references (can be empty)")
+    contributing: Optional[str] = dspy.OutputField(desc="Contributing guidelines and process")
+    license_info: Optional[str] = dspy.OutputField(desc="License information")
+    acknowledgments: Optional[str] = dspy.OutputField(desc="Acknowledgments and references (can be empty)")
 
 
 class AppendOnlyREADMEGenerator(dspy.Signature):
@@ -39,14 +39,14 @@ class AppendOnlyREADMEGenerator(dspy.Signature):
     existing_readme: str = dspy.InputField(desc="Existing README content that must not be modified")
     subfolder_readmes: str = dspy.InputField(desc="Content from README files of subfolders for context")
     
-    api_docs: str = dspy.OutputField(desc="API documentation if public APIs exist (empty if not needed)")
-    architecture: str = dspy.OutputField(desc="Architecture overview if code structure needs explanation (empty if not needed)")
-    development: str = dspy.OutputField(desc="Development setup instructions if missing (empty if not needed)")
-    testing: str = dspy.OutputField(desc="Testing instructions if absent (empty if not needed)")
-    deployment: str = dspy.OutputField(desc="Deployment notes if missing (empty if not needed)")
-    performance: str = dspy.OutputField(desc="Performance considerations if relevant (empty if not needed)")
-    security: str = dspy.OutputField(desc="Security considerations if relevant (empty if not needed)")
-    troubleshooting: str = dspy.OutputField(desc="Troubleshooting guide if needed (empty if not needed)")
+    api_docs: Optional[str] = dspy.OutputField(desc="API documentation if public APIs exist (empty if not needed)")
+    architecture: Optional[str] = dspy.OutputField(desc="Architecture overview if code structure needs explanation (empty if not needed)")
+    development: Optional[str] = dspy.OutputField(desc="Development setup instructions if missing (empty if not needed)")
+    testing: Optional[str] = dspy.OutputField(desc="Testing instructions if absent (empty if not needed)")
+    deployment: Optional[str] = dspy.OutputField(desc="Deployment notes if missing (empty if not needed)")
+    performance: Optional[str] = dspy.OutputField(desc="Performance considerations if relevant (empty if not needed)")
+    security: Optional[str] = dspy.OutputField(desc="Security considerations if relevant (empty if not needed)")
+    troubleshooting: Optional[str] = dspy.OutputField(desc="Troubleshooting guide if needed (empty if not needed)")
 
 
 class READMEModule(dspy.Module):
@@ -106,7 +106,7 @@ class READMEModule(dspy.Module):
             }
             
             for title, content in sections.items():
-                if content.strip():
+                if content and content.strip():
                     additional_sections.append(f"## {title}\n\n{content.strip()}")
             
             # Combine existing README with new sections
@@ -136,7 +136,7 @@ class READMEModule(dspy.Module):
             sections.append(f"# {result.title.strip()}")
         
         # Badges (if present)
-        if result.badges.strip():
+        if result.badges and result.badges.strip():
             sections.append(result.badges.strip())
         
         # Overview
@@ -144,7 +144,7 @@ class READMEModule(dspy.Module):
             sections.append(f"## Overview\n\n{result.overview.strip()}")
         
         # Features
-        if result.features.strip():
+        if result.features and result.features.strip():
             sections.append(f"## Features\n\n{result.features.strip()}")
         
         # Prerequisites
@@ -164,15 +164,15 @@ class READMEModule(dspy.Module):
             sections.append(f"## File Structure\n\n{result.file_structure.strip()}")
         
         # Contributing
-        if result.contributing.strip():
+        if result.contributing and result.contributing.strip():
             sections.append(f"## Contributing\n\n{result.contributing.strip()}")
         
         # License
-        if result.license_info.strip():
+        if result.license_info and result.license_info.strip():
             sections.append(f"## License\n\n{result.license_info.strip()}")
         
         # Acknowledgments
-        if result.acknowledgments.strip():
+        if result.acknowledgments and result.acknowledgments.strip():
             sections.append(f"## Acknowledgments\n\n{result.acknowledgments.strip()}")
         
         return "\n\n".join(sections)

--- a/test_optional.py
+++ b/test_optional.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Simple test to verify Optional type annotations work correctly
+"""
+
+from generate_readmes import READMEGenerator, AppendOnlyREADMEGenerator, READMEModule
+from pathlib import Path
+from typing import get_type_hints
+
+def test_type_annotations():
+    """Test that Optional type annotations are properly set"""
+    print("Testing type annotations...")
+    
+    # Check READMEGenerator annotations
+    hints = get_type_hints(READMEGenerator)
+    optional_fields = ['badges', 'features', 'contributing', 'license_info', 'acknowledgments']
+    
+    for field in optional_fields:
+        if field in hints:
+            print(f"✓ {field}: {hints[field]}")
+        else:
+            print(f"✗ {field}: Not found in type hints")
+    
+    # Check AppendOnlyREADMEGenerator annotations  
+    append_hints = get_type_hints(AppendOnlyREADMEGenerator)
+    append_fields = ['api_docs', 'architecture', 'development', 'testing', 'deployment', 'performance', 'security', 'troubleshooting']
+    
+    for field in append_fields:
+        if field in append_hints:
+            print(f"✓ {field}: {append_hints[field]}")
+        else:
+            print(f"✗ {field}: Not found in type hints")
+
+def test_none_handling():
+    """Test that assembly logic handles None values correctly"""
+    print("\nTesting None value handling...")
+    
+    # Create a mock result object
+    class MockResult:
+        title = "Test Project"
+        overview = "Test overview"
+        badges = None  # This should be skipped
+        features = "- Feature 1\n- Feature 2"
+        prerequisites = "Python 3.8+"
+        installation = "pip install test"
+        usage = "python test.py"
+        file_structure = "test.py - main file"
+        contributing = None  # This should be skipped
+        license_info = None  # This should be skipped
+        acknowledgments = "Thanks to everyone"
+    
+    # Test assembly logic
+    module = READMEModule()
+    readme_content = module._assemble_readme(MockResult())
+    
+    print("Generated README content:")
+    print("-" * 40)
+    print(readme_content)
+    print("-" * 40)
+    
+    # Check that None fields are not included
+    assert "## Contributing" not in readme_content, "Contributing section should be omitted when None"
+    assert "## License" not in readme_content, "License section should be omitted when None" 
+    assert "badges" not in readme_content.lower(), "Badges should be omitted when None"
+    assert "## Features" in readme_content, "Features should be included when not None"
+    assert "## Acknowledgments" in readme_content, "Acknowledgments should be included when not None"
+    
+    print("✓ None value handling works correctly!")
+
+if __name__ == "__main__":
+    test_type_annotations()
+    test_none_handling()
+    print("\n✓ All tests passed!")


### PR DESCRIPTION
Add Optional[str] type annotations to DSPy OutputFields for README sections that can be blank, and update assembly code to properly handle None values.

Changes:
- Added Optional type annotations to appropriate fields in READMEGenerator and AppendOnlyREADMEGenerator
- Updated assembly logic to check for None values before calling .strip()
- Ensures optional sections are properly omitted when None or empty

Fixes #4

Generated with [Claude Code](https://claude.ai/code)